### PR TITLE
Fix invalid nested JSON-LD objects for postSEO

### DIFF
--- a/src/components/SEO/SEO.jsx
+++ b/src/components/SEO/SEO.jsx
@@ -35,7 +35,7 @@ class SEO extends Component {
       }
     ];
     if (postSEO) {
-      schemaOrgJSONLD.push([
+      schemaOrgJSONLD.push(
         {
           "@context": "http://schema.org",
           "@type": "BreadcrumbList",
@@ -64,7 +64,7 @@ class SEO extends Component {
           },
           description
         }
-      ]);
+      );
     }
     return (
       <Helmet>


### PR DESCRIPTION
Hi,
   if you check one of your demo posts [structured data](https://search.google.com/structured-data/testing-tool?hl=IT#url=https%3A%2F%2Fvagr9k.github.io%2Fgatsby-advanced-starter%2Fthe-butterfly-of-the-edge) you can see that BlogPosting and BreadcrumbList objects are missing because added as nested array intead of multiple items.