### PR TITLE
Add jsx key to jsconfig.json

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,6 +4,7 @@
         "allowSyntheticDefaultImports": true,
         "experimentalDecorators": true,
         "baseUrl": "src",
+        "jsx": "react",
         "paths": {
             "*": ["*", "src/*"]
         }


### PR DESCRIPTION
This entry in the jsconfig.json allows VSCode to "Go To Definition" on components that have the `.jsx` file extension