### PR TITLE
save duplication of code[class*="language-"] selector

### DIFF
--- a/src/templates/b16-tomorrow-dark.css
+++ b/src/templates/b16-tomorrow-dark.css
@@ -17,6 +17,9 @@ pre[class*="language-"] {
     hyphens: none;
     background: #1d1f21;
     color: #c5c8c6;
+    margin: 0.5em 0;
+    overflow: auto;
+    padding: 1em;
 }
 
 pre[class*="language-"]::-moz-selection,
@@ -33,12 +36,6 @@ code[class*="language-"]::selection,
 code[class*="language-"] ::selection {
     text-shadow: none;
     background: #b4b7b4;
-}
-
-pre[class*="language-"] {
-    padding: 1em;
-    margin: 0.5em 0;
-    overflow: auto;
 }
 
 :not(pre) > code[class*="language-"] {


### PR DESCRIPTION
Please forgive me if I've got this completely wrong but from what I could see the selector is duplicated for no reason.