### PR TITLE
Invalid RSS data structure

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,7 +14,6 @@ module.exports = {
         config.siteUrl,
         config.pathPrefix
       )}/logos/logo-512.png`,
-      author: config.userName,
       copyright: config.copyright
     }
   },
@@ -114,7 +113,6 @@ module.exports = {
                 title
                 description
                 image_url
-                author
                 copyright
               }
             }
@@ -130,7 +128,6 @@ module.exports = {
                 date: edge.node.fields.date,
                 title: edge.node.frontmatter.title,
                 description: edge.node.excerpt,
-                author: rssMetadata.author,
                 url: rssMetadata.site_url + edge.node.fields.slug,
                 guid: rssMetadata.site_url + edge.node.fields.slug,
                 custom_elements: [{ "content:encoded": edge.node.html }]


### PR DESCRIPTION
About RSS data structure,  valid `author` tag position is in `item` tag but it seems no to be actually that:scream:
https://www.w3schools.com/xml/rss_tag_author.asp

We can generate `/rss.xml` from this config file, but this generated RSS is an invalid data structure so we cannot use it.

Probably best fix is to add `author` tag in each `item` tags...🤔?
At least, to merge this PR and we could generate valid RSS xml.
