### PR TITLE
Add missing Sharp transformer

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -66,6 +66,7 @@ module.exports = {
       }
     },
     "gatsby-plugin-sharp",
+    "gatsby-transformer-sharp",
     "gatsby-plugin-catch-links",
     "gatsby-plugin-twitter",
     "gatsby-plugin-sitemap",


### PR DESCRIPTION
Hey there,

Thanks for the great starter. Been using it to develop a website and all the existing configuration made my setup so much easier.

That said, I noticed that you had `gatsby-transformer-sharp` as a dependency but never included it in the `gatsby-config.js`. This makes it impossible to query ImageSharp nodes from your GraphQL queries.

This PR just adds the missing dependency in, and seemed to fix the issues on my end.

See docs: https://www.gatsbyjs.org/packages/gatsby-transformer-sharp/

```js
// In your gatsby-config.js
module.exports = {
  plugins: [`gatsby-plugin-sharp`, `gatsby-transformer-sharp`],
}
```