### PR TITLE
Added no-console to eslint-ignore list.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,7 @@
   "extends": ["airbnb", "prettier"],
   "plugins": ["react", "jsx-a11y", "import"],
   "rules": {
+    "no-console": "off",
     "react/prefer-stateless-function": "off",
     "react/prop-types": "off",
     "react/no-danger": "off",


### PR DESCRIPTION
"If you’re using Node.js, however, console is used to output information to the user and so is not strictly used for debugging purposes. If you are developing for Node.js then you most likely do not want this rule enabled." (https://eslint.org/docs/rules/no-console)