### PR TITLE
Fix issue where inline codes create links with redundant details.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,9 +47,9 @@ module.exports = {
           {
             resolve: "gatsby-remark-responsive-iframe"
           },
-          "gatsby-remark-prismjs",
           "gatsby-remark-copy-linked-files",
-          "gatsby-remark-autolink-headers"
+          "gatsby-remark-autolink-headers",
+          "gatsby-remark-prismjs"
         ]
       }
     },


### PR DESCRIPTION
`gatsby-remark-autolink-headers` should come before `gatsby-remark-prismjs`, per plugin instructions.
<img width="688" alt="Screen Shot 2019-06-17 at 1 06 03 PM" src="https://user-images.githubusercontent.com/683242/59626170-d6b93400-9100-11e9-8038-2e8d3c564b34.png">
