### PR TITLE
Ignore .DS_Store in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ public/
 
 # Bundle stats
 bundle-stats.json
+
+# macOS
+.DS_Store


### PR DESCRIPTION
This PR updates `.gitignore` to include `.DS_Store` so that it's ignored.